### PR TITLE
Uarm movement

### DIFF
--- a/SightSign/SightSign/App.config
+++ b/SightSign/SightSign/App.config
@@ -41,7 +41,7 @@
                 <value>200</value>
             </setting>
             <setting name="RobotType" serializeAs="String">
-                <value>Metal</value>
+                <value>Swift</value>
             </setting>
             <setting name="RobotComPort" serializeAs="String">
                 <value>com7</value>

--- a/SightSign/SightSign/MainWindow.xaml.cs
+++ b/SightSign/SightSign/MainWindow.xaml.cs
@@ -44,9 +44,9 @@ namespace SightSign
             var yScreen = SystemParameters.PrimaryScreenHeight;
 
             RobotArm = new RobotArm(
-                xScreen / 2.0, 
-                yScreen / 2.0, 
-                Math.Min(xScreen, yScreen) / 2.0, 
+                xScreen / 2.0,
+                yScreen / 2.0,
+                Math.Min(xScreen, yScreen) / 2.0,
                 Settings1.Default.RobotType == "Swift" ? ((IArm)new UArmSwiftPro()) : ((IArm)new UArmMetal()));
 
             _settings = new Settings(RobotArm);

--- a/SightSign/SightSign/Properties/Resources.Designer.cs
+++ b/SightSign/SightSign/Properties/Resources.Designer.cs
@@ -8,15 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-using System.CodeDom.Compiler;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Resources;
-using System.Runtime.CompilerServices;
-
 namespace SightSign.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -24,27 +19,27 @@ namespace SightSign.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [GeneratedCode("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
-    [DebuggerNonUserCode()]
-    [CompilerGenerated()]
-    internal class Resources {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
+    public class Resources {
         
-        private static ResourceManager resourceMan;
+        private static global::System.Resources.ResourceManager resourceMan;
         
-        private static CultureInfo resourceCulture;
+        private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
         
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        internal static ResourceManager ResourceManager {
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
-                if (ReferenceEquals(resourceMan, null)) {
-                    var temp = new ResourceManager("SightSign.Properties.Resources", typeof(Resources).Assembly);
+                if (object.ReferenceEquals(resourceMan, null)) {
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("SightSign.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -55,8 +50,8 @@ namespace SightSign.Properties {
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        internal static CultureInfo Culture {
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }

--- a/SightSign/SightSign/RobotArm.cs
+++ b/SightSign/SightSign/RobotArm.cs
@@ -124,9 +124,8 @@ namespace SightSign
             Move(LastPoint);
         }
 
-        //flag for movement based on orientation of robot arm 
-        //set to false for the uArm Swift pro
-        private bool _scaraMode = false;
+        // note: scara mode is only supported by UArm Metal
+        private bool _scaraMode = true;
         public void MoveRT(double r, double t)
         {
             if (!Connected) return;

--- a/SightSign/SightSign/RobotArm.cs
+++ b/SightSign/SightSign/RobotArm.cs
@@ -124,7 +124,9 @@ namespace SightSign
             Move(LastPoint);
         }
 
-        private bool _scaraMode = true;
+        //flag for movement based on orientation of robot arm 
+        //set to false for the uArm Swift pro
+        private bool _scaraMode = false;
         public void MoveRT(double r, double t)
         {
             if (!Connected) return;

--- a/SightSign/SightSign/Settings2.cs
+++ b/SightSign/SightSign/Settings2.cs
@@ -1,0 +1,28 @@
+﻿namespace SightSign.Properties {
+    
+    
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}

--- a/SightSign/SightSign/SightSign.csproj
+++ b/SightSign/SightSign/SightSign.csproj
@@ -117,6 +117,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings1.settings</DependentUpon>
     </Compile>
+    <Compile Include="Settings2.cs" />
     <Compile Include="SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>
     </Compile>
@@ -172,7 +173,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <Content Include="..\..\docs\Microsoft SightSign App EULA.md">

--- a/SightSign/SightSign/UArmSwift.cs
+++ b/SightSign/SightSign/UArmSwift.cs
@@ -36,6 +36,7 @@ namespace SightSign
             var yy = y * 100.0 * scale + 50.0;
             var zz = z * 20.0 + 50;
             System.Diagnostics.Debug.WriteLine($"X={xx} Y={yy} Z={zz}");
+
             _arm.MoveXYZ(xx, yy, zz, 20000);
         }
     }

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman


### PR DESCRIPTION
1.  Simple change to App.config to set default RobotType to "Swift" (new) instead of "Metal" (old). 
2.  RobotArm will now default to using the UArmSwift class instead of UArmMetal class.
3.  _scaraMode flag is not supported by UArmSwift, no need to change it.

